### PR TITLE
Add new search path for Wget+At | Fixes #9

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -46,7 +46,8 @@ WGET_AT = find_executable(
 	],
     [
          './wget-at',
-         '/home/warrior/data/wget-at-gnutls'
+         '/home/warrior/data/wget-at-gnutls',
+	 '/home/warrior/data/wget-at'
     ]
 )
 


### PR DESCRIPTION
The docker container contains two Wget+At binaries at `/home/warrior/data` with different versions.

The path that was added by my commit contains the executable with the correct version.